### PR TITLE
Luci-app-AdGuardHome的默认binpath不正确

### DIFF
--- a/luci-app-adguardhome/root/etc/config/AdGuardHome
+++ b/luci-app-adguardhome/root/etc/config/AdGuardHome
@@ -7,7 +7,7 @@ config AdGuardHome 'AdGuardHome'
 	option workdir '/tmp/AdGuardHome'
 	option logfile '/tmp/AdGuardHome.log'
 	option verbose '0'
-	option binpath '/usr/bin/AdGuardHome'
+	option binpath '/usr/bin/AdGuardHome/AdGuardHome'
 	option upxflag '-1'
 
 	option waitonboot '0'


### PR DESCRIPTION
更正Luci-app-AdGuardHome的默认binpath位置。
原：
option binpath '/usr/bin/AdGuardHome/AdGuardHome'
更正：
option binpath '/usr/bin/AdGuardHome/AdGuardHome/AdGuardHome'